### PR TITLE
Fix setup.sh script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -11,8 +11,8 @@ brew install zlib
 
 # Python
 
-curl -L https://briefcase-support.org/python\?platform\=iOS\&version\=3.10 -o Python-3.10-iOS-support.b1.tar.gz
 mkdir python-apple-support
+curl -L https://briefcase-support.org/python\?platform\=iOS\&version\=3.10 -o python-apple-support/Python-3.10-iOS-support.b1.tar.gz
 cd python-apple-support
 
 tar -xzvf Python-3.10-iOS-support.b1.tar.gz


### PR DESCRIPTION
The previous version had a mistake where the setup files located in Python-3.10-iOS-support.b1.tar.gz weren't properly decompressed, which caused lines 18-30 to not function and made the app impossible to build as-is.

I'm not 100% sure the app will build now (just installing Xcode on a new computer at the moment), but this should fix a number of issues currently causing 'Build Failed' issues in Xcode. 